### PR TITLE
Mods install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,4 @@ dmypy.json
 /.vs
 /umaModelReplace/backup
 /umaModelReplace/edited
-/editTexture
+/umaModelReplace/Texture2D

--- a/main.py
+++ b/main.py
@@ -2,9 +2,10 @@ import umaModelReplace
 import os
 import shutil
 import UnityPy
+from tkinter import filedialog
 
 uma = umaModelReplace.UmaReplace()
-MOD_PATH=r'.\umaModelReplace\edited'
+
 
 def replace_char_body_texture(char_id: str):
     is_not_exist, msg = uma.save_char_body_texture(char_id, False)
@@ -88,6 +89,19 @@ def replace_support_thumb_texture(card_id: str, overwrite: bool):
         uma.replace_support_thumb_texture(card_id)
 
 
+def get_bundle_name(fullPath):
+    begin = fullPath.rfind("/") + 1
+    end = fullPath.rfind(".")
+    if end != -1:
+        result = fullPath[begin:end]
+    else:
+        result = fullPath[begin:]
+    return result
+
+
+
+
+
 if __name__ == "__main__":
     while True:
         do_type = input("[11] 更换头部模型\n"
@@ -161,7 +175,7 @@ if __name__ == "__main__":
             replace_support_thumb_texture(input("支援卡ID: "), True)
 
         if do_type == "25":
-            file = r'.\umaModelReplace\Texture2D\support_card'
+            file = f"{umaModelReplace.EDITED_TEXTURE_PATH}/support_card"
             for dirpath, dirnames, filenames in os.walk(file):
                 for dirname in dirnames:
                     print(dirname)
@@ -196,11 +210,21 @@ if __name__ == "__main__":
 
 
         if do_type == "8":
-            for dirpath, dirnames, filenames in os.walk(MOD_PATH):
+            for dirpath, dirnames, filenames in os.walk(umaModelReplace.EDITED_PATH):
+               for filename in filenames:
+                   file_path = os.path.join(dirpath, filename)
+                   if os.path.isfile(uma.get_bundle_path(filename)):
+                       base = UnityPy.load(file_path)
+                       name: str
+                       for key, value in base.container.items():
+                           name = get_bundle_name(key)
+                           print(name)
+                           shutil.copyfile(file_path, f"{umaModelReplace.MOD_PATH}/{filename}")           
+            print("开始安装")
+            for dirpath, dirnames, filenames in os.walk(umaModelReplace.MOD_PATH):
                 for filename in filenames:
                     file_path = os.path.join(dirpath, filename)
                     if os.path.isfile(uma.get_bundle_path(filename)):
-                        uma.file_backup(filename)
                         shutil.copyfile(file_path, uma.get_bundle_path(filename))
 						
         if do_type == "9":

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import umaModelReplace
+import os
 
 uma = umaModelReplace.UmaReplace()
 
@@ -19,6 +20,7 @@ def replace_char_body_texture(char_id: str):
         uma.replace_char_body_texture(char_id)
         print("贴图已修改")
 
+
 def replace_char_head_texture(char_id: str):
     for n, i in enumerate(uma.save_char_head_texture(char_id, False)):
         is_not_exist, msg = i
@@ -36,37 +38,86 @@ def replace_char_head_texture(char_id: str):
                    "请输入: ")
     if do_fin.strip() in ["Y", "y"]:
         uma.replace_char_head_texture(char_id)
-        print("贴图已修改")
+
+
+def replace_support_card_texture(card_id: str, overwrite: bool):
+    if overwrite == True:
+        for n, i in enumerate(uma.save_support_card_texture(card_id, False)):
+            is_not_exist, msg = i
+
+            if not is_not_exist:
+                print(f"文件夹已存在: {msg}")
+                do_replace = input("输入 \"Y\" 覆盖已解包资源, 输入其它内容跳过导出: ")
+                if do_replace in ["Y", "y"]:
+                    _, msg = uma.save_support_card_texture(card_id, True, n)[0]
+
+                print(f"已尝试导出资源, 请查看目录: {msg}")
+
+        do_fin = input("请进行文件修改/替换, 修改完成后请输入 \"Y\" 打包并替换游戏文件。\n"
+                       "若您不想立刻修改, 可以输入其它任意内容退出, 您可以在下次替换时选择\"跳过导出\"\n"
+                       "请输入: ")
+        if do_fin.strip() in ["Y", "y"]:
+            uma.replace_support_card_texture(card_id)
+
+    else:
+        uma.replace_support_card_texture(card_id)
+
+
+def replace_support_thumb_texture(card_id: str, overwrite: bool):
+    if overwrite == True:
+        for n, i in enumerate(uma.save_support_thumb_texture(card_id, False)):
+            is_not_exist, msg = i
+
+            if not is_not_exist:
+                print(f"文件夹已存在: {msg}")
+                do_replace = input("输入 \"Y\" 覆盖已解包资源, 输入其它内容跳过导出: ")
+                if do_replace in ["Y", "y"]:
+                    _, msg = uma.save_support_thumb_texture(card_id, True, n)[0]
+
+                print(f"已尝试导出资源, 请查看目录: {msg}")
+
+        do_fin = input("请进行文件修改/替换, 修改完成后请输入 \"Y\" 打包并替换游戏文件。\n"
+                       "若您不想立刻修改, 可以输入其它任意内容退出, 您可以在下次替换时选择\"跳过导出\"\n"
+                       "请输入: ")
+        if do_fin.strip() in ["Y", "y"]:
+            uma.replace_support_thumb_texture(card_id)
+
+    else:
+        uma.replace_support_thumb_texture(card_id)
 
 
 if __name__ == "__main__":
     while True:
-        do_type = input("[1] 更换头部模型\n"
-                        "[2] 更换身体模型\n"
-                        "[3] 更换尾巴模型(不建议)\n"
-                        "[4] 更换头部与身体模型\n"
-                        "[5] 修改角色身体贴图\n"
-                        "[6] 更换抽卡开门人物\n"
-                        "[7] 更换技能动画\n"
-                        "[8] 更换G1胜利动作(实验性)\n"
-                        "[9] Live服装解锁\n"
-                        "[10] 清除Live所有模糊效果\n"
-                        "[11] 修改角色头部贴图\n"
-                        "[98] 复原所有修改\n"
-                        "[99] 退出\n"
+        do_type = input("[11] 更换头部模型\n"
+                        "[12] 更换身体模型\n"
+                        "[13] 更换尾巴模型(不建议)\n"
+                        "[14] 更换头部与身体模型\n"
+                        "[15] 更换抽卡开门人物\n"
+                        "[21] 修改角色身体贴图\n"
+                        "[22] 修改角色头部贴图\n"
+                        "[23] 修改支援卡贴图\n"
+                        "[24] 修改支援卡缩略图贴图\n"
+                        "[25] 批量修改支援卡\n"
+                        "[3]  更换技能动画\n"
+                        "[4]  更换G1胜利动作(实验性)\n"
+                        "[51] Live服装解锁\n"
+                        "[52] 清除Live所有模糊效果\n"
+                        "[9]  复原所有修改\n"
+                        "[91] 清理 backup,edited 文件夹\n"
+                        "[0] 退出\n"
                         "请选择您的操作: ")
 
-        if do_type == "1":
+        if do_type == "11":
             print("请输入7位数ID, 例: 1046_01")
             uma.replace_head(input("替换ID: "), input("目标ID: "))
             print("替换完成")
 
-        if do_type == "2":
+        if do_type == "12":
             print("请输入7位数ID, 例: 1046_01")
             uma.replace_body(input("替换ID: "), input("目标ID: "))
             print("替换完成")
 
-        if do_type == "3":
+        if do_type == "13":
             checkDo = input("注意: 目前无法跨模型更换尾巴, 更换目标不能和原马娘同时出场。\n"
                             "若您仍要更改, 请输入y继续: ")
             if checkDo not in ["y", "Y"]:
@@ -75,7 +126,7 @@ if __name__ == "__main__":
             uma.replace_tail(input("替换ID: "), input("目标ID: "))
             print("替换完成")
 
-        if do_type == "4":
+        if do_type == "14":
             print("请输入7位数ID, 例: 1046_01")
             inId1 = input("替换ID: ")
             inId2 = input("目标ID: ")
@@ -83,22 +134,42 @@ if __name__ == "__main__":
             uma.replace_body(inId1, inId2)
             print("替换完成")
 
-        if do_type == "5":
-            print("请输入7位数ID, 例: 1046_01")
-            replace_char_body_texture(input("角色7位ID: "))
-
-        if do_type == "6":
+        if do_type == "15":
             print("请输入普通开门动画的人物服装6位数ID, 例: 100101、100130")
             uma.edit_gac_chr_start(input("服装6位数ID: "), '001')
             print("请输入理事长开门动画的人物服装的6位数ID, 例: 100101、100130")
             uma.edit_gac_chr_start(input("服装6位数ID: "), '002')
             print("替换完成")
 
-        if do_type == "7":
+        if do_type == "21":
+            print("请输入7位数ID, 例: 1046_01")
+            replace_char_body_texture(input("角色7位ID: "))
+
+        if do_type == "22":
+            print("请输入7位数ID, 例: 1046_01")
+            replace_char_head_texture(input("角色7位ID: "))
+
+        if do_type == "23":
+            print("支援卡ID, 例: 20002")
+            replace_support_card_texture(input("支援卡ID: "), True)
+
+        if do_type == "24":
+            print("支援卡ID, 例: 20002")
+            replace_support_thumb_texture(input("支援卡ID: "), True)
+
+        if do_type == "25":
+            file = r'.\editTexture\support_card'
+            for dirpath, dirnames, filenames in os.walk(file):
+                for dirname in dirnames:
+                    print(dirname)
+                    replace_support_card_texture(dirname, False)
+                    replace_support_thumb_texture(dirname, False)
+
+        if do_type == "3":
             print("请输入人物技能6位数ID, 例: 100101、100102")
             uma.edit_cutin_skill(input("替换ID: "), input("目标ID: "))
 
-        if do_type == "8":
+        if do_type == "4":
             checkDo = input("注意: 目前部分胜利动作替换后会出现破音、黑屏等问题。\n"
                             "若您仍要更改, 请输入y继续: ")
             if checkDo not in ["y", "Y"]:
@@ -107,26 +178,24 @@ if __name__ == "__main__":
             uma.replace_race_result(input("替换ID: "), input("目标ID: "))
             print("替换完成")
 
-        if do_type == "9":
+        if do_type == "51":
             uma.unlock_live_dress()
             print("解锁完成")
 
-        if do_type == "10":
+        if do_type == "52":
             edit_live_id = input("Live id (通常为4位, 留空则全部修改): ").strip()
             uma.clear_live_blur(edit_live_id)
             # print("此功能搭配TLG插件的Live自由镜头功能，使用效果更佳\n"
             #       "This function is paired with the TLG plug-in's Live free camera for better use\n"
             #       "Repo: https://github.com/MinamiChiwa/Trainers-Legend-G")
 
-        if do_type == "11":
-            print("请输入7位数ID, 例: 1046_01")
-            replace_char_head_texture(input("角色7位ID: "))
-
-        if do_type == "98":
+        if do_type == "9":
             uma.file_restore()
-            print("已还原修改")
 
-        if do_type == "99":
+        if do_type == "91":
+            uma.file_delete()
+
+        if do_type == "0":
             break
 
         input("Press enter to continue...\n")

--- a/main.py
+++ b/main.py
@@ -99,9 +99,6 @@ def get_bundle_name(fullPath):
     return result
 
 
-
-
-
 if __name__ == "__main__":
     while True:
         do_type = input("[11] 更换头部模型\n"
@@ -206,30 +203,27 @@ if __name__ == "__main__":
             #       "This function is paired with the TLG plug-in's Live free camera for better use\n"
             #       "Repo: https://github.com/MinamiChiwa/Trainers-Legend-G")
 
-
-
-
         if do_type == "8":
             for dirpath, dirnames, filenames in os.walk(umaModelReplace.EDITED_PATH):
-               for filename in filenames:
-                   file_path = os.path.join(dirpath, filename)
-                   if os.path.isfile(uma.get_bundle_path(filename)):
-                       base = UnityPy.load(file_path)
-                       name: str
-                       for key, value in base.container.items():
-                           name = get_bundle_name(key)
-                           print(name)
-                           shutil.copyfile(file_path, f"{umaModelReplace.MOD_PATH}/{filename}")           
+                for filename in filenames:
+                    file_path = os.path.join(dirpath, filename)
+                    if os.path.isfile(uma.get_bundle_path(filename)):
+                        base = UnityPy.load(file_path)
+                        name: str
+                        for key, value in base.container.items():
+                            name = get_bundle_name(key)
+                            print(name)
+                            shutil.copyfile(file_path, f"{umaModelReplace.MOD_PATH}/{filename}")
             print("开始安装")
             for dirpath, dirnames, filenames in os.walk(umaModelReplace.MOD_PATH):
                 for filename in filenames:
                     file_path = os.path.join(dirpath, filename)
                     if os.path.isfile(uma.get_bundle_path(filename)):
                         shutil.copyfile(file_path, uma.get_bundle_path(filename))
-						
+
         if do_type == "9":
             uma.file_restore()
-			
+
         if do_type == "91":
             uma.file_delete()
 

--- a/main.py
+++ b/main.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
             replace_support_thumb_texture(input("支援卡ID: "), True)
 
         if do_type == "25":
-            file = r'.\editTexture\support_card'
+            file = r'.\umaModelReplace\Texture2D\support_card'
             for dirpath, dirnames, filenames in os.walk(file):
                 for dirname in dirnames:
                     print(dirname)

--- a/main.py
+++ b/main.py
@@ -219,7 +219,7 @@ if __name__ == "__main__":
                 for filename in filenames:
                     file_path = os.path.join(dirpath, filename)
                     if os.path.isfile(uma.get_bundle_path(filename)):
-                        shutil.copyfile(file_path, uma.get_bundle_path(filename))
+                        shutil.move(file_path, uma.get_bundle_path(filename))
 
         if do_type == "9":
             uma.file_restore()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 import umaModelReplace
 import os
+import shutil
+import UnityPy
 
 uma = umaModelReplace.UmaReplace()
-
+MOD_PATH=r'.\umaModelReplace\edited'
 
 def replace_char_body_texture(char_id: str):
     is_not_exist, msg = uma.save_char_body_texture(char_id, False)
@@ -102,6 +104,7 @@ if __name__ == "__main__":
                         "[4]  更换G1胜利动作(实验性)\n"
                         "[51] Live服装解锁\n"
                         "[52] 清除Live所有模糊效果\n"
+                        "[8]  安装MOD\n"
                         "[9]  复原所有修改\n"
                         "[91] 清理 backup,edited 文件夹\n"
                         "[0] 退出\n"
@@ -189,9 +192,20 @@ if __name__ == "__main__":
             #       "This function is paired with the TLG plug-in's Live free camera for better use\n"
             #       "Repo: https://github.com/MinamiChiwa/Trainers-Legend-G")
 
+
+
+
+        if do_type == "8":
+            for dirpath, dirnames, filenames in os.walk(MOD_PATH):
+                for filename in filenames:
+                    file_path = os.path.join(dirpath, filename)
+                    if os.path.isfile(uma.get_bundle_path(filename)):
+                        uma.file_backup(filename)
+                        shutil.copyfile(file_path, uma.get_bundle_path(filename))
+						
         if do_type == "9":
             uma.file_restore()
-
+			
         if do_type == "91":
             uma.file_delete()
 

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,1 @@
+python main.py

--- a/umaModelReplace/assets_path.py
+++ b/umaModelReplace/assets_path.py
@@ -92,3 +92,15 @@ def get_head_mtl_path(_id):
         f"sourceresources/3d/chara/head/chr{_id}/materials/mtl_chr{_id}_face",
         f"sourceresources/3d/chara/head/chr{_id}/materials/mtl_chr{_id}_hair"
     ]
+
+
+def get_support_card_path(_id):
+    return [
+        f"supportcard/support{_id}/tex_support_card_{_id}"
+    ]
+
+
+def get_support_thumb_path(_id):
+    return [
+        f"supportcard/support{_id}/support_thumb_{_id}"
+    ]

--- a/umaModelReplace/main.py
+++ b/umaModelReplace/main.py
@@ -13,6 +13,7 @@ BACKUP_PATH = f"{spath}/backup"
 EDITED_PATH = f"{spath}/edited"
 EDITED_TEXTURE_PATH = f"{spath}/Texture2D"
 
+
 class UmaFileNotFoundError(FileNotFoundError):
     pass
 
@@ -21,8 +22,9 @@ class UmaReplace:
     def __init__(self):
         self.init_folders()
         profile_path = os.environ.get("UserProfile")
-#        self.base_path = f"{profile_path}/AppData/LocalLow/Cygames/umamusume"
-        self.base_path = filedialog.askdirectory(title='选择同时包含dat文件夹,meta文件的文件夹',initialdir=f"{profile_path}/AppData/LocalLow/Cygames/umamusume") #选择同时包含dat文件夹,meta文件的文件夹
+        #        self.base_path = f"{profile_path}/AppData/LocalLow/Cygames/umamusume"
+        self.base_path = filedialog.askdirectory(title='选择同时包含dat文件夹,meta文件的文件夹',
+                                                 initialdir=f"{profile_path}/AppData/LocalLow/Cygames/umamusume")  # 选择同时包含dat文件夹,meta文件的文件夹
         self.conn = sqlite3.connect(f"{self.base_path}/meta")
         self.master_conn = sqlite3.connect(f"{self.base_path}/master/master.mdb")
 
@@ -56,7 +58,7 @@ class UmaReplace:
                 shutil.copyfile(fpath, self.get_bundle_path(i))
                 print(f"restore {i}")
         print("已还原修改")
-		
+
     def file_delete(self):
         do_delete = input("即将清理 backup,edited 文件夹,输入 \"Y\" 确认: ")
         if do_delete in ["Y", "y"]:
@@ -64,11 +66,12 @@ class UmaReplace:
             if do_restore in ["Y", "y"]:
                 self.file_restore()
             shutil.rmtree(BACKUP_PATH)
-            shutil.rmtree(EDITED_PATH)				
+            shutil.rmtree(EDITED_PATH)
             self.init_folders()
             print("已清理")
-        else:print("取消清理")
-				
+        else:
+            print("取消清理")
+
     @staticmethod
     def replace_file_path(fname: str, id1: str, id2: str, save_name: t.Optional[str] = None) -> str:
         env = UnityPy.load(fname)
@@ -116,8 +119,7 @@ class UmaReplace:
                 f.write(env.file.save())
         return save_name
 
-
-    def replace_texture2d(self, edited_path: str,bundle_name: str):
+    def replace_texture2d(self, edited_path: str, bundle_name: str):
         if not os.path.isdir(edited_path):
             raise UmaFileNotFoundError(f"path: {edited_path} not found. Please extract first.")
         if os.path.exists(self.get_bundle_path(bundle_name)):
@@ -138,7 +140,8 @@ class UmaReplace:
                 f.write(env.file.save())
         return save_name
 
-    def get_texture_in_bundle(self, base_path: str,bundle_name: str, src_names: t.Optional[t.List[str]], force_replace=False):
+    def get_texture_in_bundle(self, base_path: str, bundle_name: str, src_names: t.Optional[t.List[str]],
+                              force_replace=False):
         if not os.path.isdir(base_path):
             os.makedirs(base_path)
 
@@ -156,7 +159,7 @@ class UmaReplace:
                         image: Image = img_data.image
                         image.save(f"{base_path}/{data.name}.png")
                         print(f"save {data.name} into {f'{base_path}/{data.name}.png'}")
-        return True, base_path	
+        return True, base_path
 
     def get_bundle_hash(self, path: str, query_orig_id: t.Optional[str]) -> str:
         cursor = self.conn.cursor()
@@ -173,7 +176,7 @@ class UmaReplace:
 
         if query is None:
             print(UmaFileNotFoundError(f"{path} not found!"))
-            query=[]
+            query = []
             return query
         cursor.close()
         return query[0]
@@ -181,7 +184,8 @@ class UmaReplace:
     def save_char_body_texture(self, char_id: str, force_replace=False):
         mtl_bdy_path = assets_path.get_body_mtl_path(char_id)
         bundle_hash = self.get_bundle_hash(mtl_bdy_path, None)
-        return self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/char_body/{char_id}",bundle_hash, assets_path.get_body_mtl_names(char_id), force_replace)
+        return self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/char_body/{char_id}", bundle_hash,
+                                          assets_path.get_body_mtl_names(char_id), force_replace)
 
     def save_char_head_texture(self, char_id: str, force_replace=False, on_index=-1):
         ret = []
@@ -190,17 +194,15 @@ class UmaReplace:
                 if n != on_index:
                     continue
             bundle_hash = self.get_bundle_hash(i, None)
-            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/char_head/{char_id}",bundle_hash, None, force_replace))
+            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/char_head/{char_id}", bundle_hash, None,
+                                                  force_replace))
         return ret
-		
 
-
-		
     def replace_char_body_texture(self, char_id: str):
         mtl_bdy_path = assets_path.get_body_mtl_path(char_id)
         bundle_hash = self.get_bundle_hash(mtl_bdy_path, None)
         self.file_backup(bundle_hash)
-        edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/char_body/{char_id}",bundle_hash)
+        edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/char_body/{char_id}", bundle_hash)
         # print("save", edited_path)
         shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))
 
@@ -208,10 +210,9 @@ class UmaReplace:
         for mtl_bdy_path in assets_path.get_head_mtl_path(char_id):
             bundle_hash = self.get_bundle_hash(mtl_bdy_path, None)
             self.file_backup(bundle_hash)
-            edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/char_head/{char_id}",bundle_hash)
+            edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/char_head/{char_id}", bundle_hash)
             # print("save", edited_path)
             shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))
-
 
     def save_support_card_texture(self, card_id: str, force_replace=False, on_index=-1):
         ret = []
@@ -220,20 +221,18 @@ class UmaReplace:
                 if n != on_index:
                     continue
             bundle_hash = self.get_bundle_hash(i, None)
-            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}",bundle_hash, None, force_replace))
+            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}", bundle_hash, None,
+                                                  force_replace))
         return ret
 
-
-			
-			
     def replace_support_card_texture(self, card_id: str):
         for support_card_path in assets_path.get_support_card_path(card_id):
             bundle_hash = self.get_bundle_hash(support_card_path, None)
             if bundle_hash != []:
                 self.file_backup(bundle_hash)
-                edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}",bundle_hash)
+                edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}", bundle_hash)
                 # print("save", edited_path)
-                shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))		
+                shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))
                 print("贴图已修改")
 
     def save_support_thumb_texture(self, card_id: str, force_replace=False, on_index=-1):
@@ -243,23 +242,20 @@ class UmaReplace:
                 if n != on_index:
                     continue
             bundle_hash = self.get_bundle_hash(i, None)
-            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}",bundle_hash, None, force_replace))
+            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}", bundle_hash, None,
+                                                  force_replace))
         return ret
 
-
-			
-			
     def replace_support_thumb_texture(self, card_id: str):
         for support_thumb_path in assets_path.get_support_thumb_path(card_id):
             bundle_hash = self.get_bundle_hash(support_thumb_path, None)
             if bundle_hash != []:
                 self.file_backup(bundle_hash)
-                edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}",bundle_hash)
+                edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}", bundle_hash)
                 # print("save", edited_path)
-                shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))		
+                shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))
                 print("贴图已修改")
-				
-		
+
     def replace_file_ids(self, orig_path: str, new_path: str, id_orig: str, id_new: str):
         orig_hash = self.get_bundle_hash(orig_path, id_orig)
         new_hash = self.get_bundle_hash(new_path, id_new)

--- a/umaModelReplace/main.py
+++ b/umaModelReplace/main.py
@@ -119,14 +119,14 @@ class UmaReplace:
                 f.write(env.file.save())
         return save_name
 
-    def replace_texture2d(self, bundle_name: str):
-        edited_path = f"{EDUT_TEXTURE_PATH}/{bundle_name}"
+    def replace_texture2d(self, path: str):
+        edited_path = f"{EDUT_TEXTURE_PATH}/{path}"
         if not os.path.isdir(edited_path):
             raise UmaFileNotFoundError(f"path: {edited_path} not found. Please extract first.")
-        if os.path.exists(self.get_bundle_path(bundle_name)):
+        if os.path.exists(self.get_bundle_path(path)):
             file_names = os.listdir(edited_path)
-            save_name = f"{EDITED_PATH}/{os.path.split(bundle_name)[-1]}"
-            env = UnityPy.load(self.get_bundle_path(bundle_name))
+            save_name = f"{EDITED_PATH}/{os.path.split(path)[-1]}"
+            env = UnityPy.load(self.get_bundle_path(path))
             for obj in env.objects:
                 if obj.type.name == "Texture2D":
                     data = obj.read()

--- a/umaModelReplace/main.py
+++ b/umaModelReplace/main.py
@@ -59,8 +59,9 @@ class UmaReplace:
         for i in hashs:
             fpath = f"{BACKUP_PATH}/{i}"
             if os.path.isfile(fpath):
-                shutil.copyfile(fpath, self.get_bundle_path(i))
-                print(f"restore {i}")
+                if os.path.exists(self.get_bundle_path(i)):
+                    shutil.move(fpath, self.get_bundle_path(i))
+                    print(f"restore {i}")
         print("已还原修改")
 
     def file_delete(self):

--- a/umaModelReplace/main.py
+++ b/umaModelReplace/main.py
@@ -12,7 +12,8 @@ spath = os.path.split(__file__)[0]
 BACKUP_PATH = f"{spath}/backup"
 EDITED_PATH = f"{spath}/edited"
 EDITED_TEXTURE_PATH = f"{spath}/Texture2D"
-MOD_PATH= f"{spath}/Mods"
+MOD_PATH = f"{spath}/Mods"
+
 
 class UmaFileNotFoundError(FileNotFoundError):
     pass
@@ -37,10 +38,8 @@ class UmaReplace:
         if not os.path.isdir(MOD_PATH):
             os.makedirs(MOD_PATH)
 
-
     def get_bundle_path(self, bundle_hash: str):
         return f"{self.base_path}/dat/{bundle_hash[:2]}/{bundle_hash}"
-
 
     def file_backup(self, bundle_hash: str):
         if not os.path.isfile(f"{BACKUP_PATH}/{bundle_hash}"):

--- a/umaModelReplace/main.py
+++ b/umaModelReplace/main.py
@@ -12,7 +12,7 @@ spath = os.path.split(__file__)[0]
 BACKUP_PATH = f"{spath}/backup"
 EDITED_PATH = f"{spath}/edited"
 EDITED_TEXTURE_PATH = f"{spath}/Texture2D"
-
+MOD_PATH= f"{spath}/Mods"
 
 class UmaFileNotFoundError(FileNotFoundError):
     pass
@@ -34,9 +34,13 @@ class UmaReplace:
             os.makedirs(BACKUP_PATH)
         if not os.path.isdir(EDITED_PATH):
             os.makedirs(EDITED_PATH)
+        if not os.path.isdir(MOD_PATH):
+            os.makedirs(MOD_PATH)
+
 
     def get_bundle_path(self, bundle_hash: str):
         return f"{self.base_path}/dat/{bundle_hash[:2]}/{bundle_hash}"
+
 
     def file_backup(self, bundle_hash: str):
         if not os.path.isfile(f"{BACKUP_PATH}/{bundle_hash}"):
@@ -163,7 +167,7 @@ class UmaReplace:
 
     def get_bundle_hash(self, path: str, query_orig_id: t.Optional[str]) -> str:
         cursor = self.conn.cursor()
-        query = cursor.execute("SELECT h FROM a WHERE n=?", [path]).fetchone()
+        query = cursor.execute("SELECT h FROM a WHERE n like ?", [path]).fetchone()
         if query is None:
             if (query_orig_id is not None) and ("_" in query_orig_id):
                 query_id, query_sub_id = query_orig_id.split("_")

--- a/umaModelReplace/main.py
+++ b/umaModelReplace/main.py
@@ -11,7 +11,7 @@ from tkinter import filedialog
 spath = os.path.split(__file__)[0]
 BACKUP_PATH = f"{spath}/backup"
 EDITED_PATH = f"{spath}/edited"
-
+EDITED_TEXTURE_PATH = f"{spath}/Texture2D"
 
 class UmaFileNotFoundError(FileNotFoundError):
     pass
@@ -116,31 +116,8 @@ class UmaReplace:
                 f.write(env.file.save())
         return save_name
 
-    def replace_texture2d(self, bundle_name: str):
-        edited_path = f"./editTexture/{bundle_name}"
-        if not os.path.isdir(edited_path):
-            raise UmaFileNotFoundError(f"path: {edited_path} not found. Please extract first.")
-        if os.path.exists(self.get_bundle_path(bundle_name)):
-            file_names = os.listdir(edited_path)
-            save_name = f"{EDITED_PATH}/{os.path.split(bundle_name)[-1]}"
-            env = UnityPy.load(self.get_bundle_path(bundle_name))
-            for obj in env.objects:
-                if obj.type.name == "Texture2D":
-                    data = obj.read()
-                    if hasattr(data, "name"):
-                        if f"{data.name}.png" in file_names:
-                            img_data = data.read()
-                            img_data.image = Image.open(f"{edited_path}/{data.name}.png")
-                            data.save()
 
-        
-            with open(save_name, "wb") as f:
-                f.write(env.file.save())
-			
-        return save_name
-
-    def replace_support_card_texture2d(self, card_id: str,bundle_name: str):
-        edited_path = f"./editTexture/support_card/{card_id}"
+    def replace_texture2d(self, edited_path: str,bundle_name: str):
         if not os.path.isdir(edited_path):
             raise UmaFileNotFoundError(f"path: {edited_path} not found. Please extract first.")
         if os.path.exists(self.get_bundle_path(bundle_name)):
@@ -161,29 +138,7 @@ class UmaReplace:
                 f.write(env.file.save())
         return save_name
 
-    def get_texture_in_bundle(self, bundle_name: str, src_names: t.Optional[t.List[str]], force_replace=False):
-        base_path = f"./editTexture/{bundle_name}"
-        if not os.path.isdir(base_path):
-            os.makedirs(base_path)
-
-        if not force_replace:
-            if len(os.listdir(base_path)) > 0:
-                return False, base_path
-
-        env = UnityPy.load(self.get_bundle_path(bundle_name))
-        for obj in env.objects:
-            if obj.type.name == "Texture2D":
-                data = obj.read()
-                if hasattr(data, "name"):
-                    if src_names is None or (data.name in src_names):
-                        img_data = data.read()
-                        image: Image = img_data.image
-                        image.save(f"{base_path}/{data.name}.png")
-                        print(f"save {data.name} into {f'{base_path}/{data.name}.png'}")
-        return True, base_path	
-
-    def get_support_card_texture_in_bundle(self, card_id: str,bundle_name: str, src_names: t.Optional[t.List[str]], force_replace=False):
-        base_path = f"./editTexture/support_card/{card_id}"
+    def get_texture_in_bundle(self, base_path: str,bundle_name: str, src_names: t.Optional[t.List[str]], force_replace=False):
         if not os.path.isdir(base_path):
             os.makedirs(base_path)
 
@@ -226,7 +181,7 @@ class UmaReplace:
     def save_char_body_texture(self, char_id: str, force_replace=False):
         mtl_bdy_path = assets_path.get_body_mtl_path(char_id)
         bundle_hash = self.get_bundle_hash(mtl_bdy_path, None)
-        return self.get_texture_in_bundle(bundle_hash, assets_path.get_body_mtl_names(char_id), force_replace)
+        return self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/char_body/{char_id}",bundle_hash, assets_path.get_body_mtl_names(char_id), force_replace)
 
     def save_char_head_texture(self, char_id: str, force_replace=False, on_index=-1):
         ret = []
@@ -235,7 +190,7 @@ class UmaReplace:
                 if n != on_index:
                     continue
             bundle_hash = self.get_bundle_hash(i, None)
-            ret.append(self.get_texture_in_bundle(bundle_hash, None, force_replace))
+            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/char_head/{char_id}",bundle_hash, None, force_replace))
         return ret
 		
 
@@ -245,7 +200,7 @@ class UmaReplace:
         mtl_bdy_path = assets_path.get_body_mtl_path(char_id)
         bundle_hash = self.get_bundle_hash(mtl_bdy_path, None)
         self.file_backup(bundle_hash)
-        edited_path = self.replace_texture2d(bundle_hash)
+        edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/char_body/{char_id}",bundle_hash)
         # print("save", edited_path)
         shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))
 
@@ -253,7 +208,7 @@ class UmaReplace:
         for mtl_bdy_path in assets_path.get_head_mtl_path(char_id):
             bundle_hash = self.get_bundle_hash(mtl_bdy_path, None)
             self.file_backup(bundle_hash)
-            edited_path = self.replace_texture2d(bundle_hash)
+            edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/char_head/{char_id}",bundle_hash)
             # print("save", edited_path)
             shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))
 
@@ -265,7 +220,7 @@ class UmaReplace:
                 if n != on_index:
                     continue
             bundle_hash = self.get_bundle_hash(i, None)
-            ret.append(self.get_support_card_texture_in_bundle(card_id,bundle_hash, None, force_replace))
+            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}",bundle_hash, None, force_replace))
         return ret
 
 
@@ -276,7 +231,7 @@ class UmaReplace:
             bundle_hash = self.get_bundle_hash(support_card_path, None)
             if bundle_hash != []:
                 self.file_backup(bundle_hash)
-                edited_path = self.replace_support_card_texture2d(card_id,bundle_hash)
+                edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}",bundle_hash)
                 # print("save", edited_path)
                 shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))		
                 print("贴图已修改")
@@ -288,7 +243,7 @@ class UmaReplace:
                 if n != on_index:
                     continue
             bundle_hash = self.get_bundle_hash(i, None)
-            ret.append(self.get_support_card_texture_in_bundle(card_id,bundle_hash, None, force_replace))
+            ret.append(self.get_texture_in_bundle(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}",bundle_hash, None, force_replace))
         return ret
 
 
@@ -299,7 +254,7 @@ class UmaReplace:
             bundle_hash = self.get_bundle_hash(support_thumb_path, None)
             if bundle_hash != []:
                 self.file_backup(bundle_hash)
-                edited_path = self.replace_support_card_texture2d(card_id,bundle_hash)
+                edited_path = self.replace_texture2d(f"{EDITED_TEXTURE_PATH}/support_card/{card_id}",bundle_hash)
                 # print("save", edited_path)
                 shutil.copyfile(edited_path, self.get_bundle_path(bundle_hash))		
                 print("贴图已修改")


### PR DESCRIPTION
新增文件夹Mods，新增功能 安装mod
主要功能是把edited文件夹中符华要求的文件复制到Mods，再将Mods文件夹中所有文件移动到游戏目录
要求指游戏版本对应，即台服只能要台服的文件，edited文件夹中如果同时包含日服台服的文件，会根据启动时选择的游戏目录是台服还是日服判断那些文件可以被移动Mods文件夹再移动到游戏目录

另外还原文件的功能 file_restore 加了个判断，也是为了不把其他版本的赛马娘文件还原了，并且把还原功能的复制改成了移动

呜呜呜，代码用pycharm格式化过了